### PR TITLE
permutations in feature_importance

### DIFF
--- a/man/feature_importance.Rd
+++ b/man/feature_importance.Rd
@@ -4,19 +4,19 @@
 \alias{feature_importance}
 \alias{feature_importance.explainer}
 \alias{feature_importance.default}
-\title{Feature Importance Plots}
+\title{Feature Importance}
 \usage{
 feature_importance(x, ...)
 
 \method{feature_importance}{explainer}(x,
-  loss_function = loss_root_mean_square, ..., type = "raw",
-  n_sample = NULL, variables = NULL, variable_groups = NULL,
-  label = NULL)
+  loss_function = loss_root_mean_square, ..., type = c("raw", "ratio",
+  "difference"), n_sample = NULL, B = 1, variables = NULL,
+  variable_groups = NULL, label = NULL)
 
 \method{feature_importance}{default}(x, data, y, predict_function,
   loss_function = loss_root_mean_square, ..., label = class(x)[1],
-  type = "raw", n_sample = NULL, variables = NULL,
-  variable_groups = NULL)
+  type = c("raw", "ratio", "difference"), n_sample = NULL, B = 1,
+  variables = NULL, variable_groups = NULL)
 }
 \arguments{
 \item{x}{a model to be explained, or an explainer created with function `DALEX::explain()`.}
@@ -28,6 +28,8 @@ feature_importance(x, ...)
 \item{type}{character, type of transformation that should be applied for dropout loss. 'raw' results raw drop lossess, 'ratio' returns \code{drop_loss/drop_loss_full_model} while 'difference' returns \code{drop_loss - drop_loss_full_model}}
 
 \item{n_sample}{number of observations that should be sampled for calculation of variable importance. If NULL then variable importance will be calculated on whole dataset (no sampling).}
+
+\item{B}{integer, number of permutation rounds to perform on each variable}
 
 \item{variables}{vector of variables. If NULL then variable importance will be tested for each variable from the `data` separately. By default NULL}
 

--- a/man/feature_importance.Rd
+++ b/man/feature_importance.Rd
@@ -10,13 +10,15 @@ feature_importance(x, ...)
 
 \method{feature_importance}{explainer}(x,
   loss_function = loss_root_mean_square, ..., type = c("raw", "ratio",
-  "difference"), n_sample = NULL, B = 1, variables = NULL,
+  "difference"), n_sample = NULL, B = 1,
+  keep_raw_permutations = NULL, variables = NULL,
   variable_groups = NULL, label = NULL)
 
 \method{feature_importance}{default}(x, data, y, predict_function,
   loss_function = loss_root_mean_square, ..., label = class(x)[1],
   type = c("raw", "ratio", "difference"), n_sample = NULL, B = 1,
-  variables = NULL, variable_groups = NULL)
+  keep_raw_permutations = NULL, variables = NULL,
+  variable_groups = NULL)
 }
 \arguments{
 \item{x}{a model to be explained, or an explainer created with function `DALEX::explain()`.}
@@ -30,6 +32,8 @@ feature_importance(x, ...)
 \item{n_sample}{number of observations that should be sampled for calculation of variable importance. If NULL then variable importance will be calculated on whole dataset (no sampling).}
 
 \item{B}{integer, number of permutation rounds to perform on each variable}
+
+\item{keep_raw_permutations}{logical or NULL, determines if output retains information for individual permutations; default is to omit for B=1 and keep otherwise}
 
 \item{variables}{vector of variables. If NULL then variable importance will be tested for each variable from the `data` separately. By default NULL}
 

--- a/tests/testthat/test_variable_dropout.R
+++ b/tests/testthat/test_variable_dropout.R
@@ -67,12 +67,30 @@ test_that("feature_importance records number of permutations", {
   raw <- attr(result, "raw_permutations")
   expect_is(raw, "data.frame")
   # the raw permutations data frame will have:
-  # - three columns: feature, permutation, dropout_loss
+  # - three columns: feature, permutation, dropout_loss, label
   # - many rows: one per permutation and per feature (plus baseline, plus full)
-  expect_equal(dim(raw), c(nrow(result)*2, 3))
+  expect_equal(dim(raw), c(nrow(result)*2, 4))
   # because there is no sub-sampling, all the full-model results should be equal
   loss_full <- raw[raw$variable=="_full_model_",]
   expect_equal(length(unique(loss_full$dropout_loss)), 1)
+})
+
+
+test_that("feature_importance avoids reporting permutations when only one performed", {
+  # by default, one permutation leads to no raw_permutations component
+  result_default <- feature_importance(explainer_rf, B = 1)
+  expect_true(is.null(attr(result_default, "raw_permutations")))
+  result_keep <- feature_importance(explainer_rf, B = 1, keep_raw_permutations = TRUE)
+  expect_false(is.null(attr(result_keep, "raw_permutations")))
+})
+
+
+test_that("feature_importance can avoid recording permutation details", {
+  result <- feature_importance(explainer_rf, B = 2, keep_raw_permutations = FALSE)
+  expect_true(is.null(attr(result, "raw_permutations")))
+  # when keep_raw_permutations is off, output should still signal number of permutations
+  expect_false(is.null(attr(result, "B")))
+  expect_equal(attr(result, "B"), 2)
 })
 
 

--- a/tests/testthat/test_variable_dropout.R
+++ b/tests/testthat/test_variable_dropout.R
@@ -1,5 +1,29 @@
 context("Check feature_importance() function")
 
+
+# Usability - tests with improper inputs
+
+test_that("feature_importance checks its inputs", {
+  missing.data <- list()
+  class(missing.data) <- "explainer"
+  expect_error(feature_importance(missing.data), "data")
+  missing.y <- list(data = data.frame(A=1:2))
+  class(missing.y) <- "explainer"
+  expect_error(feature_importance(missing.y), "y")
+})
+
+
+test_that("feature_importance stops with incorrect type", {
+  # error message should provide hints on the allowed values for type
+  expect_error(feature_importance(explainer_glm, type = "a"), "raw")
+  expect_error(feature_importance(explainer_glm, type = "a"), "ratio")
+})
+
+
+
+
+# Correctness - tests with good inputs
+
 test_that("Output glm",{
   vd_glm <- feature_importance(explainer_glm, type = "raw",
                                      loss_function = loss_root_mean_square)
@@ -15,7 +39,76 @@ test_that("Output rf",{
 
 
 
+# Permutations and subsampling
 
+test_that("feature_importance can use sub-sampling", {
+  # When using n_sample =1, the effective dataset is reduced to only one row.
+  # A "permutation" of a one-row dataset is always equal to the original dataset.
+  # Thus a model acting on the original data and on the permuted data gives
+  # the same output for both. Thus, none of the features will appear "important".
+  # Thus, all dropout_loss values should be equal.
+  # Practically, this can be tested: sum to be equal to a multiple of the first item
+  result <- feature_importance(explainer_rf, n_sample = 1)
+  expect_equal(sum(result$dropout_loss), nrow(result)*result$dropout_loss[1],
+               tolerance = 1e-12)
+})
+
+
+test_that("feature_importance gives slightly different output on subsequent runs", {
+  result_1 <- feature_importance(explainer_rf)
+  result_2 <- feature_importance(explainer_rf)
+  change_12 <- abs(result_1$dropout_loss - result_2$dropout_loss)
+  expect_gt(sum(change_12), 0)
+})
+
+
+test_that("feature_importance records number of permutations", {
+  result <- feature_importance(explainer_rf, B = 2)
+  expect_false(is.null(attr(result, "B")))
+  expect_equal(attr(result, "B"), 2)
+  expect_false(is.null(attr(result, "raw_permutations")))
+  raw <- attr(result, "raw_permutations")
+  expect_is(raw, "data.frame")
+  # the raw permutations data frame will have:
+  # - three columns: feature, permutation, dropout_loss
+  # - many rows: one per permutation and per feature plus outcome
+  n1 <- nrow(result) - 1
+  expect_equal(dim(raw), c(n1*2, 3))
+})
+
+
+test_that("feature_importance performs at least one permutation", {
+  result <- feature_importance(explainer_rf, B = 0.1)
+  expect_false(is.null(attr(result, "B")))
+  expect_equal(attr(result, "B"), 1)
+})
+
+
+test_that("feature_importance averaged over many permutations are stable", {
+  # this test uses many permutations, so make a very small titanic dataset for speed
+  tiny <- titanic_small[titanic_small$Age > 50,]
+  tiny$Parch <- tiny$SibSp <- tiny$Embarked <- tiny$Sex <- NULL
+  tiny_rf <- randomForest(Survived ~ Pclass + Fare + Age, data = tiny)
+  tiny_explainer = explain(tiny_rf, data = tiny,
+                           y = tiny$Survived=="1", label = "RF")
+  # compute single permutations importance values
+  result_1 <- feature_importance(tiny_explainer)
+  result_2 <- feature_importance(tiny_explainer)
+  # compute feature importance with several permutations 
+  result_A <- feature_importance(tiny_explainer, B = 40)
+  result_B <- feature_importance(tiny_explainer, B = 40)
+  # two rounds with many permutation should give results closer together
+  # than two rounds with single permutations 
+  change_12 <- abs(result_1$dropout_loss - result_2$dropout_loss)
+  change_AB <- abs(result_A$dropout_loss - result_B$dropout_loss)
+  # this test should succeed most of the time... but in principle could fail by accident
+  expect_lt(sum(change_AB), sum(change_12))
+})
+
+
+
+
+# Variable grouping
 
 test_that("Variable groupings validation", {
   vd_rf <- feature_importance(explainer_rf,
@@ -24,34 +117,50 @@ test_that("Variable groupings validation", {
                                                        "ticket_type" = c("Pclass", "Fare"))
                               )
   expect_is(vd_rf, "feature_importance_explainer")
-
 })
-
 
 
 test_that("Variable groupings input validation checks", {
   expect_warning(feature_importance(explainer_rf,
                                     loss_function = loss_root_mean_square,
                                     variable_groups = list(c("Sex", "Age"),
-                                                             c("Pclass", "Fare"))), "You have passed an unnamed list. The names of variable groupings will be created from variables names.")
-
+                                                           c("Pclass", "Fare"))),
+                 "You have passed an unnamed list. The names of variable groupings will be created from variables names.")
+  
   expect_error( feature_importance(explainer_rf,
                                    loss_function = loss_root_mean_square,
                                    variable_groups = c("Sex", "Age")
-  ), "variable_groups should be of class list")
-
-   expect_error(feature_importance(explainer_rf,
-                                   loss_function = loss_root_mean_square,
-                                   variable_groups = list("demographics" = c("wrong_name", "Age"))
-   ), "You have passed wrong variables names in variable_groups argument")
-
+                                   ),
+               "variable_groups should be of class list")
+  
   expect_error(feature_importance(explainer_rf,
-    loss_function = loss_root_mean_square,
-  variable_groups = list("demographics" = list("Sex", "Age"))
-), "Elements of variable_groups argument should be of class character")
-
+                                  loss_function = loss_root_mean_square,
+                                  variable_groups = list("demographics" = c("wrong_name", "Age"))
+                                  ),
+               "You have passed wrong variables names in variable_groups argument")
+  
+  expect_error(feature_importance(explainer_rf,
+                                  loss_function = loss_root_mean_square,
+                                  variable_groups = list("demographics" = list("Sex", "Age"))
+                                  ),
+               "Elements of variable_groups argument should be of class character")
 })
 
 
 
+
+# Output types
+
+test_that("feature_importance with type ratio", {
+  # type "ratio" gives $dropout_loss normalized by _full_model_
+  result <- feature_importance(explainer_rf, type="ratio")
+  expect_equal(result$dropout_loss[result$variable=="_full_model_"], 1)
+})
+
+
+test_that("feature_importance with type difference", {
+  # type "difference" gives $dropout_loss with _full_model_ subtracted
+  result <- feature_importance(explainer_rf, type="difference")
+  expect_equal(result$dropout_loss[result$variable=="_full_model_"], 0)
+})
 


### PR DESCRIPTION
Updates to function `feature_importance` following discussion in #29 

 - argument `B`, determines number of permutations carried out on each variable. Output object gives average dropout_loss over these permutations
 - argument `keep_raw_permutations`, determines whether or not output object should contain details of all the permutations. Details are provided in attribute `raw_permutations`.

Comments

 - some minor edits to inner code (match.arg)
 - testthat chunks for new arguments based on titanic data
 - some testthat chunks for miscellaneous items in feature_importance
 - output is accepted in plot
 - code passes `devtools::test()`