### PR TITLE
fix bug in feature_importance when data is a matrix

### DIFF
--- a/R/feature_importance.R
+++ b/R/feature_importance.R
@@ -173,7 +173,7 @@ feature_importance.default <- function(x,
     if (!inherits(variable_groups, "list")) stop("variable_groups should be of class list")
 
     wrong_names <- !all(sapply(variable_groups, function(variable_set) {
-      all(variable_set %in% names(data))
+      all(variable_set %in% colnames(data))
     }))
 
     if (wrong_names) stop("You have passed wrong variables names in variable_groups argument")

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -1,4 +1,5 @@
 library("randomForest")
+library("xgboost")
 library("titanic")
 library("DALEX")
 
@@ -14,6 +15,8 @@ loss_cross_entropy <- function (observed, predicted, p_min = 0.0001) {
 }
 
 
+# Random Forest
+# Example of a model built using a data frame
 titanic_small <- titanic_train[,c("Survived", "Pclass", "Sex", "Age",
                                   "SibSp", "Parch", "Fare", "Embarked")]
 titanic_small$Survived <- factor(titanic_small$Survived)
@@ -25,3 +28,17 @@ rf_model <- randomForest(Survived ~ Pclass + Sex + Age + SibSp + Parch + Fare + 
 explainer_rf <- explain(rf_model, data = titanic_small,
                         y = titanic_small$Survived == "1", label = "RF")
 
+
+# xgboost (using matrix object)
+# Example of a model that relies on a numeric matrix
+titanic_small_mat <- titanic_small
+titanic_small_survived <- 0 + (titanic_small$Survived==1)
+titanic_small_mat$Survived <- NULL # remove outcome from dataset
+titanic_small_mat$Embarked <- NULL # skip embarked because it is messy to convert into numeric)
+titanic_small_mat$Sex <- 0 + (titanic_small_mat$Sex=="male")
+titanic_small_mat <- as.matrix(titanic_small_mat)
+xgb_model <- xgboost(data=titanic_small_mat, label=titanic_small_survived,
+                     nrounds=2, verbose=FALSE)
+explainer_xgb <- explain(xgb_model,
+                         data=titanic_small_mat,
+                         y=titanic_small_survived, label="xgboost")

--- a/tests/testthat/test_variable_dropout.R
+++ b/tests/testthat/test_variable_dropout.R
@@ -138,13 +138,26 @@ test_that("feature_importance averaged over many permutations are stable", {
 
 # Variable grouping
 
-test_that("Variable groupings validation", {
+test_that("Variable groupings validation with data frame", {
   vd_rf <- feature_importance(explainer_rf,
                               loss_function = loss_root_mean_square,
-                              variable_groups = list("demographics" = c("Sex", "Age"),
-                                                       "ticket_type" = c("Pclass", "Fare"))
+                              variable_groups = list(
+                                siblings_souse = c("SibSp"),
+                                demographics = c("Sex", "Age"),
+                                ticket_type = c("Pclass", "Fare"))
                               )
   expect_is(vd_rf, "feature_importance_explainer")
+})
+
+
+test_that("Variable groupings validation with matrix", {
+  result <- feature_importance(explainer_xgb,
+                               variable_groups = list(
+                                 siblings_souse = c("SibSp"),
+                                 demographics = c("Sex", "Age"),
+                                 ticket_type = c("Pclass", "Fare"))
+                               )
+  expect_is(result, "feature_importance_explainer")
 })
 
 


### PR DESCRIPTION
Resolves #42 

 - The fix only involves changing `names` to `colnames` in one line of the `feature_importance` function
 - The helper objects for the test suites now include a matrix-like titanic dataset and a trained xgboost model
 - The test suite has an additional test that uses the matrix-based titanic dataset and xgboost model